### PR TITLE
Dockerfile: make sure tsc and ts-node are installed globally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 
 COPY . .
 
+RUN npm install -g tsc ts-node
 RUN npm --prefix /app/server install
 RUN npm --prefix /app/web install
 


### PR DESCRIPTION
Fixes:
```
  remote: > notion2anki-server@0.7.11 build
  remote: > tsc -p .
  remote:
  remote: sh: 1: tsc: not found
  remote: The command '/bin/sh -c npm --prefix /app/server run build' returned a non-zero code: 127
  remote: 2021/12/12 03:40:31 exit status 127
```