### PR TITLE
web/footer: fix broken link for scrimba logo

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -84,7 +84,7 @@ const Footer = () => {
           <p>
             <a href="http://scrimba.com">
               <img
-                src="sponsors/Scrimba.png"
+                src="/sponsors/Scrimba.png"
                 alt="Sponsored by Scrimba"
                 loading="lazy"
               />


### PR DESCRIPTION
It's currently a broken image. Don't know when this regression happened, it was working before. 