### PR TITLE
github/workflows: limit deployment to one instance

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    concurrency: "production"
     steps:
       - uses: actions/checkout@v1
       - name: Dokku deploy


### PR DESCRIPTION
This should prevent multiple deploys when merging low hanging fruit pull
request before all actions finish.