### PR TITLE
refactor: use conditional statement instead of switch

### DIFF
--- a/web/config-overrides.js
+++ b/web/config-overrides.js
@@ -1,27 +1,23 @@
 /* config-overrides.js */
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
 module.exports = function override(config) {
-        if (!config.plugins) {
-                config.plugins = [];
-        }
-        config.plugins.push(
-                new MonacoWebpackPlugin()
-        );
-        switch (process.env.NODE_ENV) {
-                case 'production':
-                        config.plugins = config.plugins.filter(plugin => {
-                                return plugin.constructor.name !== 'ForkTsCheckerWebpackPlugin';
-                        });
-                        return config;
-                default:
-                        let forkTsCheckerWebpackPlugin = config.plugins.find(plugin => {
-                                return plugin.constructor.name === 'ForkTsCheckerWebpackPlugin';
-                        });
-                        forkTsCheckerWebpackPlugin.memoryLimit = 4096;
-                        return config;
-        }
+  if (!config.plugins) {
+    config.plugins = [];
+  }
+  config.plugins.push(new MonacoWebpackPlugin());
+  if (process.env.NODE_ENV === "production") {
+    config.plugins = config.plugins.filter((plugin) => {
+      return plugin.constructor.name !== "ForkTsCheckerWebpackPlugin";
+    });
+    return config;
+  }
+
+  let forkTsCheckerWebpackPlugin = config.plugins.find((plugin) => {
+    return plugin.constructor.name === "ForkTsCheckerWebpackPlugin";
+  });
+  forkTsCheckerWebpackPlugin.memoryLimit = 4096;
+  return config;
 };
 // Ref https://github.com/microsoft/monaco-editor/issues/82
 // Ref https://www.gitmemory.com/issue/facebook/create-react-app/7135/497102755


### PR DESCRIPTION
This is to address a sonar code smell:
> "switch" statements should have at least 3 "case" clauses