### PR TITLE
Synchronize the main branch to use main branch in the server (git submodule)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ docker_push:
 	docker push ${project}
 ssr:
 	git add server && \
-	git commit -m 'server: $(shell cd server && git push origin main && git --no-pager log -1 --pretty='tformat:%h (%s, %ad)' --date=short)'
+	git commit -m 'chore: $(shell cd server && git push origin main && git --no-pager log -1 --pretty='tformat:%h (%s, %ad)' --date=short)'


### PR DESCRIPTION
The diff here won't show everything but there is a private `main` and previously there was `stable` branch for the server submodule. The server submodule will be phased out soon and it will be changed into a regular directory with all of the code being public.