### PR TITLE
chore: do not run server tests on dependabot pull requests

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    if: github.actor!= 'dependabot'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
It won't work due to environment secrets unavailable.