### PR TITLE
fix: set PACKAGEJSON_DIR for release bumping

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -15,8 +15,8 @@ jobs:
         uses: 'actions/checkout@v2'
         with:
           ref: ${{ github.ref }}
-      - name: 'cat server/package.json'
-        run: cat ./server/package.json
+      - name: 'cat package.json'
+        run: cat package.json
       - name: 'Automated Version Bump'
         id: version-bump
         uses: 'phips28/gh-action-bump-version@master'
@@ -24,8 +24,9 @@ jobs:
           tag-prefix: 'v'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'cat server/package.json'
-        run: cat ./server/package.json
+          PACKAGEJSON_DIR: 'server'
+      - name: 'cat package.json'
+        run: cat package.json
       - name: 'Output Step'
         env:
           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}


### PR DESCRIPTION
Hopefully fixes the following issue

```
2022-04-11T20:05:44.9667178Z (node:1614) UnhandledPromiseRejectionWarning: Error: package.json could not be found in your project's root.
2022-04-11T20:05:44.9668877Z     at getPackageJson (/home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:211:41)
2022-04-11T20:05:44.9670129Z     at /home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:16:15
2022-04-11T20:05:44.9670833Z     at Object.<anonymous> (/home/runner/work/_actions/phips28/gh-action-bump-version/master/index.js:207:3)
2022-04-11T20:05:44.9671291Z     at Module._compile (internal/modules/cjs/loader.js:999:30)
2022-04-11T20:05:44.9671844Z     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
2022-04-11T20:05:44.9672224Z     at Module.load (internal/modules/cjs/loader.js:863:32)
2022-04-11T20:05:44.9672723Z     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
2022-04-11T20:05:44.9673134Z     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
2022-04-11T20:05:44.9673505Z     at internal/main/run_main_module.js:17:47
2022-04-11T20:05:44.9687002Z (node:1614) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
2022-04-11T20:05:44.9688702Z (node:1614) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
2022-04-11T20:05:44.9774500Z ##[group]Run cat ./server/package.json
2022-04-11T20:05:44.9774852Z t ./server/package.json
```