### PR TITLE
chore: exclude templates and test fixtures from Sonar

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=server/templates/**,server/test/fixtures/**


### PR DESCRIPTION
Hopefully fixes false positives.