### PR TITLE
chore: remove old error message for Markdown support

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion2anki-server",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion2anki-server",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^0.4.12",

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/server/routes/upload/helpers/TriggerUnsupportedFormat.ts
+++ b/server/routes/upload/helpers/TriggerUnsupportedFormat.ts
@@ -1,5 +1,0 @@
-export default function TriggerUnsupportedFormat() {
-  throw new Error(
-    'Markdown support has been removed, please use <a class="button" href="https://www.notion.so/Export-as-HTML-bf3fe9e6920e4b9883cbd8a76b6128b7">HTML</a>'
-  );
-}

--- a/server/routes/upload/helpers/handleUpload.ts
+++ b/server/routes/upload/helpers/handleUpload.ts
@@ -1,7 +1,6 @@
 import { nanoid } from "nanoid";
 import express from "express";
 
-import TriggerUnsupportedFormat from "./TriggerUnsupportedFormat";
 import StorageHandler from "../../../lib/storage/StorageHandler";
 import { PrepareDeck } from "../../../lib/parser/DeckParser";
 import { BytesToMegaBytes } from "../../../lib/misc/file";
@@ -53,8 +52,6 @@ export default async function handleUpload(
         );
         const pkg = new Package(d.name, d.apkg);
         packages = packages.concat(pkg);
-      } else if (filename.match(/.md$/)) {
-        TriggerUnsupportedFormat();
       } else {
         const zipHandler = new ZipHandler();
         /* @ts-ignore */
@@ -63,8 +60,6 @@ export default async function handleUpload(
           if (fileName.match(/.html$/) && !fileName.includes("/")) {
             const d = await PrepareDeck(fileName, zipHandler.files, settings);
             packages.push(new Package(d.name, d.apkg));
-          } else if (fileName.match(/.md$/)) {
-            TriggerUnsupportedFormat();
           }
         }
       }


### PR DESCRIPTION
We might bring it back but regardless there is fallback in place so we
don't need to this to throw error in production.